### PR TITLE
Fix clang-tidy warnings with better CPP semantics, memory alignments,…

### DIFF
--- a/cmake/process_options.cmake
+++ b/cmake/process_options.cmake
@@ -99,6 +99,7 @@ if(ENABLE_OPENMP)
             "Install OpenMP or set ENABLE_OPENMP OFF.")
     endif()
 
+    target_link_libraries(lightning_compile_options INTERFACE OpenMP::OpenMP_CXX)
     target_link_libraries(lightning_external_libs INTERFACE OpenMP::OpenMP_CXX)
 else()
     message(STATUS "ENABLE_OPENMP is OFF.")

--- a/pennylane_lightning/src/simulators/lightning_qubit/gates/CMakeLists.txt
+++ b/pennylane_lightning/src/simulators/lightning_qubit/gates/CMakeLists.txt
@@ -46,7 +46,7 @@ else()
     set(KERNEL_MAP_FILES    KernelMap_Default.cpp
                             AssignKernelMap_Default.cpp CACHE INTERNAL "" FORCE)
     add_library(pl_qubit_gates_kernel_map STATIC ${KERNEL_MAP_FILES})
-    target_link_libraries(pl_qubit_gates_kernel_map PRIVATE  pl_qubit_utils)
+    target_link_libraries(pl_qubit_gates_kernel_map PRIVATE  pl_qubit_utils lightning_external_libs lightning_compile_options)
 
     add_library(pl_qubit_gates_register_kernels_default STATIC RegisterKernels_Default.cpp cpu_kernels/GateImplementationsLM.cpp cpu_kernels/GateImplementationsPI.cpp GateIndices.cpp)
     target_include_directories(pl_qubit_gates_register_kernels_default PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/pennylane_lightning/src/simulators/lightning_qubit/gates/RegisterKernel.hpp
+++ b/pennylane_lightning/src/simulators/lightning_qubit/gates/RegisterKernel.hpp
@@ -166,8 +166,8 @@ void registerAllImplementedGateOps() {
     };
 
     [[maybe_unused]] const auto registered_gate_ops = std::apply(
-        [&registerGateToDispatcher](auto... elt) {
-            return std::make_tuple(registerGateToDispatcher(elt)...);
+        [&registerGateToDispatcher](auto... elem) {
+            return std::make_tuple(registerGateToDispatcher(elem)...);
         },
         gate_op_functor_tuple<PrecisionT, ParamT, GateImplementation>);
 }
@@ -190,8 +190,8 @@ void registerAllImplementedGeneratorOps() {
         };
 
     [[maybe_unused]] const auto registered_gntr_ops = std::apply(
-        [&registerGeneratorToDispatcher](auto... elt) {
-            return std::make_tuple(registerGeneratorToDispatcher(elt)...);
+        [&registerGeneratorToDispatcher](auto... elem) {
+            return std::make_tuple(registerGeneratorToDispatcher(elem)...);
         },
         generator_op_functor_tuple<PrecisionT, GateImplementation>);
 }
@@ -214,8 +214,8 @@ void registerAllImplementedMatrixOps() {
     };
 
     [[maybe_unused]] const auto registered_mat_ops = std::apply(
-        [&registerMatrixToDispatcher](auto... elt) {
-            return std::make_tuple(registerMatrixToDispatcher(elt)...);
+        [&registerMatrixToDispatcher](auto... elem) {
+            return std::make_tuple(registerMatrixToDispatcher(elem)...);
         },
         matrix_op_functor_tuple<PrecisionT, GateImplementation>);
 }

--- a/pennylane_lightning/src/simulators/lightning_qubit/gates/tests/CreateAllWires.hpp
+++ b/pennylane_lightning/src/simulators/lightning_qubit/gates/tests/CreateAllWires.hpp
@@ -70,7 +70,7 @@ class CombinationGenerator : public WiresGenerator {
 class PermutationGenerator : public WiresGenerator {
   private:
     std::vector<std::vector<size_t>> all_perms_;
-    std::vector<size_t> available_elts_;
+    std::vector<size_t> available_elems_;
     std::vector<size_t> v;
 
   public:
@@ -80,18 +80,18 @@ class PermutationGenerator : public WiresGenerator {
             return;
         }
         for (size_t i = 0; i < n; i++) {
-            v[r - 1] = available_elts_[i];
-            std::swap(available_elts_[n - 1], available_elts_[i]);
+            v[r - 1] = available_elems_[i];
+            std::swap(available_elems_[n - 1], available_elems_[i]);
             perm(n - 1, r - 1);
-            std::swap(available_elts_[n - 1], available_elts_[i]);
+            std::swap(available_elems_[n - 1], available_elems_[i]);
         }
     }
 
     PermutationGenerator(size_t n, size_t r) {
         v.resize(r);
 
-        available_elts_.resize(n);
-        std::iota(available_elts_.begin(), available_elts_.end(), 0);
+        available_elems_.resize(n);
+        std::iota(available_elems_.begin(), available_elems_.end(), 0);
         perm(n, r);
     }
 
@@ -111,7 +111,7 @@ class PermutationGenerator : public WiresGenerator {
  */
 auto inline createAllWires(size_t n_qubits, Gates::GateOperation gate_op,
                            bool order) -> std::vector<std::vector<size_t>> {
-    if (array_has_elt(Gates::Constant::multi_qubit_gates, gate_op)) {
+    if (array_has_elem(Gates::Constant::multi_qubit_gates, gate_op)) {
         // make all possible 2^N permutations
         std::vector<std::vector<size_t>> res;
         res.reserve((1U << n_qubits) - 1);

--- a/pennylane_lightning/src/simulators/lightning_qubit/gates/tests/TestConstant.hpp
+++ b/pennylane_lightning/src/simulators/lightning_qubit/gates/tests/TestConstant.hpp
@@ -1,6 +1,6 @@
 #include "Constant.hpp"
-#include "ConstantTestHelpers.hpp" // count_unique, first_elts_of, second_elts_of
-#include "ConstantUtil.hpp"        // array_has_elt
+#include "ConstantTestHelpers.hpp" // count_unique, first_elems_of, second_elems_of
+#include "ConstantUtil.hpp"        // array_has_elem
 #include "GateOperation.hpp"
 #include "Util.hpp"
 
@@ -8,8 +8,8 @@ namespace Pennylane::LightningQubit::Gates {
 template <typename T, size_t size1, size_t size2>
 constexpr auto are_mutually_disjoint(const std::array<T, size1> &arr1,
                                      const std::array<T, size2> &arr2) -> bool {
-    return std::all_of(arr1.begin(), arr1.end(), [&arr2](const auto &elt) {
-        return !Util::array_has_elt(arr2, elt);
+    return std::all_of(arr1.begin(), arr1.end(), [&arr2](const auto &elem) {
+        return !Util::array_has_elem(arr2, elem);
     });
 }
 
@@ -20,10 +20,10 @@ constexpr auto are_mutually_disjoint(const std::array<T, size1> &arr1,
 static_assert(Constant::gate_names.size() ==
                   static_cast<size_t>(GateOperation::END),
               "Constant gate_names must be defined for all gate operations.");
-static_assert(Util::count_unique(Util::first_elts_of(Constant::gate_names)) ==
+static_assert(Util::count_unique(Util::first_elems_of(Constant::gate_names)) ==
                   Constant::gate_names.size(),
               "First elements of gate_names must be distinct.");
-static_assert(Util::count_unique(Util::second_elts_of(Constant::gate_names)) ==
+static_assert(Util::count_unique(Util::second_elems_of(Constant::gate_names)) ==
                   Constant::gate_names.size(),
               "Second elements of gate_names must be distinct.");
 
@@ -33,8 +33,8 @@ static_assert(Util::count_unique(Util::second_elts_of(Constant::gate_names)) ==
 
 constexpr auto check_generator_names_starts_with() -> bool {
     const auto &arr = Constant::generator_names;
-    return std::all_of(arr.begin(), arr.end(), [](const auto &elt) {
-        const auto &[gntr_op, gntr_name] = elt;
+    return std::all_of(arr.begin(), arr.end(), [](const auto &elem) {
+        const auto &[gntr_op, gntr_name] = elem;
         return gntr_name.substr(0, 9) == "Generator";
     });
     return true;
@@ -45,11 +45,11 @@ static_assert(
         static_cast<size_t>(GeneratorOperation::END),
     "Constant generator_names must be defined for all generator operations.");
 static_assert(
-    Util::count_unique(Util::first_elts_of(Constant::generator_names)) ==
+    Util::count_unique(Util::first_elems_of(Constant::generator_names)) ==
         Constant::generator_names.size(),
     "First elements of generator_names must be distinct.");
 static_assert(
-    Util::count_unique(Util::second_elts_of(Constant::generator_names)) ==
+    Util::count_unique(Util::second_elems_of(Constant::generator_names)) ==
         Constant::generator_names.size(),
     "Second elements of generator_names must be distinct.");
 static_assert(check_generator_names_starts_with(),
@@ -65,10 +65,10 @@ static_assert(Constant::gate_wires.size() ==
               "Constant gate_wires must be defined for all gate operations "
               "acting on a fixed number of qubits.");
 static_assert(
-    are_mutually_disjoint(Util::first_elts_of(Constant::gate_wires),
+    are_mutually_disjoint(Util::first_elems_of(Constant::gate_wires),
                           Constant::multi_qubit_gates),
     "Constant gate_wires must not define values for multi-qubit gates.");
-static_assert(Util::count_unique(Util::first_elts_of(Constant::gate_wires)) ==
+static_assert(Util::count_unique(Util::first_elems_of(Constant::gate_wires)) ==
                   Constant::gate_wires.size(),
               "First elements of gate_wires must be distinct.");
 
@@ -83,12 +83,12 @@ static_assert(
     "Constant generator_wires must be defined for all generator operations "
     "acting on a fixed number of qubits.");
 static_assert(
-    are_mutually_disjoint(Util::first_elts_of(Constant::generator_wires),
+    are_mutually_disjoint(Util::first_elems_of(Constant::generator_wires),
                           Constant::multi_qubit_generators),
     "Constant generator_wires must not define values for multi-qubit "
     "generators.");
 static_assert(
-    Util::count_unique(Util::first_elts_of(Constant::generator_wires)) ==
+    Util::count_unique(Util::first_elems_of(Constant::generator_wires)) ==
         Constant::generator_wires.size(),
     "First elements of generator_wires must be distinct.");
 } // namespace Pennylane::LightningQubit::Gates

--- a/pennylane_lightning/src/simulators/lightning_qubit/gates/tests/Test_GateImplementations_CompareKernels.cpp
+++ b/pennylane_lightning/src/simulators/lightning_qubit/gates/tests/Test_GateImplementations_CompareKernels.cpp
@@ -3,7 +3,7 @@
 #include "TestHelpers.hpp"
 #include "TestKernels.hpp"
 
-#include "ConstantUtil.hpp" // lookup, array_has_elt
+#include "ConstantUtil.hpp" // lookup, array_has_elem
 #include "DynamicDispatcher.hpp"
 #include "KernelMap.hpp"
 #include "KernelType.hpp"
@@ -148,7 +148,7 @@ TEMPLATE_TEST_CASE("Test all kernels give the same results for gates",
     std::mt19937 re{1337};
     for_each_enum<GateOperation>([&](GateOperation gate_op) {
         const size_t min_num_qubits = [=] {
-            if (array_has_elt(Gates::Constant::multi_qubit_gates, gate_op)) {
+            if (array_has_elem(Gates::Constant::multi_qubit_gates, gate_op)) {
                 return size_t{1};
             }
             return lookup(Gates::Constant::gate_wires, gate_op);

--- a/pennylane_lightning/src/simulators/lightning_qubit/gates/tests/Test_GateImplementations_Generator.cpp
+++ b/pennylane_lightning/src/simulators/lightning_qubit/gates/tests/Test_GateImplementations_Generator.cpp
@@ -1,4 +1,4 @@
-#include "ConstantUtil.hpp" // lookup, array_has_elt, prepend_to_tuple, tuple_to_array
+#include "ConstantUtil.hpp" // lookup, array_has_elem, prepend_to_tuple, tuple_to_array
 #include "CreateAllWires.hpp"
 #include "DynamicDispatcher.hpp"
 #include "TestHelpers.hpp"
@@ -69,7 +69,7 @@ template <size_t gntr_idx> constexpr auto generatorGatePairsIter() {
 }
 
 constexpr auto minNumQubitsFor(GeneratorOperation gntr_op) -> size_t {
-    if (array_has_elt(Constant::multi_qubit_generators, gntr_op)) {
+    if (array_has_elem(Constant::multi_qubit_generators, gntr_op)) {
         return 1;
     }
     return lookup(Constant::generator_wires, gntr_op);

--- a/pennylane_lightning/src/simulators/lightning_qubit/gates/tests/Test_GateImplementations_Matrix.cpp
+++ b/pennylane_lightning/src/simulators/lightning_qubit/gates/tests/Test_GateImplementations_Matrix.cpp
@@ -1,4 +1,4 @@
-#include "ConstantUtil.hpp"      // array_has_elt
+#include "ConstantUtil.hpp"      // array_has_elem
 #include "LQubitTestHelpers.hpp" // PrecisionToName
 #include "LinearAlgebra.hpp"     // randomUnitary
 #include "TestHelpers.hpp"
@@ -762,16 +762,16 @@ void testApplyMatrixForKernels() {
     if constexpr (!std::is_same_v<TypeList, void>) {
         using GateImplementation = typename TypeList::Type;
 
-        if constexpr (array_has_elt(GateImplementation::implemented_matrices,
-                                    MatrixOperation::SingleQubitOp)) {
+        if constexpr (array_has_elem(GateImplementation::implemented_matrices,
+                                     MatrixOperation::SingleQubitOp)) {
             testApplySingleQubitOp<PrecisionT, GateImplementation>();
         }
-        if constexpr (array_has_elt(GateImplementation::implemented_matrices,
-                                    MatrixOperation::TwoQubitOp)) {
+        if constexpr (array_has_elem(GateImplementation::implemented_matrices,
+                                     MatrixOperation::TwoQubitOp)) {
             testApplyTwoQubitOp<PrecisionT, GateImplementation>();
         }
-        if constexpr (array_has_elt(GateImplementation::implemented_matrices,
-                                    MatrixOperation::MultiQubitOp)) {
+        if constexpr (array_has_elem(GateImplementation::implemented_matrices,
+                                     MatrixOperation::MultiQubitOp)) {
             testApplyMultiQubitOp<PrecisionT, GateImplementation>();
         }
         testApplyMatrixForKernels<PrecisionT, typename TypeList::Next>();
@@ -964,16 +964,16 @@ void testApplyMatrixInverseForKernels() {
     using Gates::MatrixOperation;
     if constexpr (!std::is_same_v<TypeList, void>) {
         using GateImplementation = typename TypeList::Type;
-        if constexpr (array_has_elt(GateImplementation::implemented_matrices,
-                                    MatrixOperation::SingleQubitOp)) {
+        if constexpr (array_has_elem(GateImplementation::implemented_matrices,
+                                     MatrixOperation::SingleQubitOp)) {
             testApplySingleQubitOpInverse<PrecisionT, GateImplementation>();
         }
-        if constexpr (array_has_elt(GateImplementation::implemented_matrices,
-                                    MatrixOperation::TwoQubitOp)) {
+        if constexpr (array_has_elem(GateImplementation::implemented_matrices,
+                                     MatrixOperation::TwoQubitOp)) {
             testApplyTwoQubitOpInverse<PrecisionT, GateImplementation>();
         }
-        if constexpr (array_has_elt(GateImplementation::implemented_matrices,
-                                    MatrixOperation::MultiQubitOp)) {
+        if constexpr (array_has_elem(GateImplementation::implemented_matrices,
+                                     MatrixOperation::MultiQubitOp)) {
             testApplyMultiQubitOpInverse<PrecisionT, GateImplementation>();
         }
         testApplyMatrixInverseForKernels<PrecisionT, typename TypeList::Next>();

--- a/pennylane_lightning/src/simulators/lightning_qubit/gates/tests/Test_GateImplementations_Nonparam.cpp
+++ b/pennylane_lightning/src/simulators/lightning_qubit/gates/tests/Test_GateImplementations_Nonparam.cpp
@@ -274,15 +274,19 @@ PENNYLANE_RUN_TEST(CNOT);
 template <typename PrecisionT, class GateImplementation> void testApplyCY() {
     using ComplexPrecisionT = std::complex<PrecisionT>;
     const size_t num_qubits = 3;
-    auto ini_st =
-        createProductState<PrecisionT>("+10"); // Test using |+10> state
-
-    CHECK(ini_st ==
-          std::vector<ComplexPrecisionT>{
-              ZERO<PrecisionT>(), ZERO<PrecisionT>(),
-              std::complex<PrecisionT>(1.0 / sqrt(2), 0), ZERO<PrecisionT>(),
-              ZERO<PrecisionT>(), ZERO<PrecisionT>(),
-              std::complex<PrecisionT>(1.0 / sqrt(2), 0), ZERO<PrecisionT>()});
+    auto ini_st_aligned = createProductState<PrecisionT>(
+        "+10"); // Test using |+10> state using AlignedAllocator
+    std::vector<ComplexPrecisionT> ini_st{
+        ini_st_aligned.begin(),
+        ini_st_aligned
+            .end()}; // Converted aligned data to default vector alignment
+    CHECK(ini_st == std::vector<ComplexPrecisionT>{
+                        ZERO<PrecisionT>(), ZERO<PrecisionT>(),
+                        std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0),
+                        ZERO<PrecisionT>(), ZERO<PrecisionT>(),
+                        ZERO<PrecisionT>(),
+                        std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0),
+                        ZERO<PrecisionT>()});
 
     DYNAMIC_SECTION(GateImplementation::name
                     << ", CY 0,1 |+10> -> i|100> - "
@@ -290,9 +294,9 @@ template <typename PrecisionT, class GateImplementation> void testApplyCY() {
         std::vector<ComplexPrecisionT> expected{
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
-            std::complex<PrecisionT>(1.0 / sqrt(2), 0),
+            std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0),
             ZERO<PrecisionT>(),
-            std::complex<PrecisionT>(0, -1 / sqrt(2)),
+            std::complex<PrecisionT>(0, -INVSQRT2<PrecisionT>()),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>()};
@@ -308,12 +312,12 @@ template <typename PrecisionT, class GateImplementation> void testApplyCY() {
         std::vector<ComplexPrecisionT> expected{
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
-            std::complex<PrecisionT>(1.0 / sqrt(2), 0.0),
+            std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0.0),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
-            std::complex<PrecisionT>(0.0, 1 / sqrt(2))};
+            std::complex<PrecisionT>(0.0, INVSQRT2<PrecisionT>())};
 
         auto sv02 = ini_st;
 
@@ -324,10 +328,14 @@ template <typename PrecisionT, class GateImplementation> void testApplyCY() {
                     << ", CY 1,2 |+10> -> i|+11> - "
                     << PrecisionToName<PrecisionT>::value) {
         std::vector<ComplexPrecisionT> expected{
-            ZERO<PrecisionT>(), ZERO<PrecisionT>(),
-            ZERO<PrecisionT>(), std::complex<PrecisionT>(0.0, 1.0 / sqrt(2)),
-            ZERO<PrecisionT>(), ZERO<PrecisionT>(),
-            ZERO<PrecisionT>(), std::complex<PrecisionT>(0.0, 1 / sqrt(2))};
+            ZERO<PrecisionT>(),
+            ZERO<PrecisionT>(),
+            ZERO<PrecisionT>(),
+            std::complex<PrecisionT>(0.0, INVSQRT2<PrecisionT>()),
+            ZERO<PrecisionT>(),
+            ZERO<PrecisionT>(),
+            ZERO<PrecisionT>(),
+            std::complex<PrecisionT>(0.0, INVSQRT2<PrecisionT>())};
 
         auto sv12 = ini_st;
 
@@ -342,19 +350,23 @@ template <typename PrecisionT, class GateImplementation> void testApplyCZ() {
     using ComplexPrecisionT = std::complex<PrecisionT>;
     const size_t num_qubits = 3;
 
-    auto ini_st = createProductState<PrecisionT>("+10");
-
+    auto ini_st_aligned = createProductState<PrecisionT>(
+        "+10"); // Test using |+10> state using AlignedAllocator
+    std::vector<ComplexPrecisionT> ini_st{
+        ini_st_aligned.begin(),
+        ini_st_aligned
+            .end()}; // Converted aligned data to default vector alignment
     DYNAMIC_SECTION(GateImplementation::name
                     << ", CZ0,1 |+10> -> |-10> - "
                     << PrecisionToName<PrecisionT>::value) {
         std::vector<ComplexPrecisionT> expected{
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
-            std::complex<PrecisionT>(1.0 / sqrt(2), 0),
+            std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
-            std::complex<PrecisionT>(-1 / sqrt(2), 0),
+            std::complex<PrecisionT>(-INVSQRT2<PrecisionT>(), 0),
             ZERO<PrecisionT>()};
 
         auto sv01 = ini_st;
@@ -402,9 +414,12 @@ PENNYLANE_RUN_TEST(CZ);
 template <typename PrecisionT, class GateImplementation> void testApplySWAP() {
     using ComplexPrecisionT = std::complex<PrecisionT>;
     const size_t num_qubits = 3;
-    auto ini_st = createProductState<PrecisionT>("+10");
-
-    // Test using |+10> state
+    auto ini_st_aligned = createProductState<PrecisionT>(
+        "+10"); // Test using |+10> state using AlignedAllocator
+    std::vector<ComplexPrecisionT> ini_st{
+        ini_st_aligned.begin(),
+        ini_st_aligned
+            .end()}; // Converted aligned data to default vector alignment
 
     CHECK(ini_st == std::vector<ComplexPrecisionT>{
                         ZERO<PrecisionT>(), ZERO<PrecisionT>(),
@@ -420,9 +435,9 @@ template <typename PrecisionT, class GateImplementation> void testApplySWAP() {
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
-            std::complex<PrecisionT>(1.0 / sqrt(2), 0),
+            std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0),
             ZERO<PrecisionT>(),
-            std::complex<PrecisionT>(1.0 / sqrt(2), 0),
+            std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0),
             ZERO<PrecisionT>()};
         auto sv01 = ini_st;
         auto sv10 = ini_st;
@@ -440,8 +455,8 @@ template <typename PrecisionT, class GateImplementation> void testApplySWAP() {
         std::vector<ComplexPrecisionT> expected{
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
-            std::complex<PrecisionT>(1.0 / sqrt(2), 0),
-            std::complex<PrecisionT>(1.0 / sqrt(2), 0),
+            std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0),
+            std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
@@ -460,10 +475,14 @@ template <typename PrecisionT, class GateImplementation> void testApplySWAP() {
                     << ", SWAP1,2 |+10> -> |+01> - "
                     << PrecisionToName<PrecisionT>::value) {
         std::vector<ComplexPrecisionT> expected{
-            ZERO<PrecisionT>(), std::complex<PrecisionT>(1.0 / sqrt(2), 0),
-            ZERO<PrecisionT>(), ZERO<PrecisionT>(),
-            ZERO<PrecisionT>(), std::complex<PrecisionT>(1.0 / sqrt(2), 0),
-            ZERO<PrecisionT>(), ZERO<PrecisionT>()};
+            ZERO<PrecisionT>(),
+            std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0),
+            ZERO<PrecisionT>(),
+            ZERO<PrecisionT>(),
+            ZERO<PrecisionT>(),
+            std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0),
+            ZERO<PrecisionT>(),
+            ZERO<PrecisionT>()};
 
         auto sv12 = ini_st;
         auto sv21 = ini_st;
@@ -484,7 +503,12 @@ template <typename PrecisionT, class GateImplementation>
 void testApplyToffoli() {
     using ComplexPrecisionT = std::complex<PrecisionT>;
     const size_t num_qubits = 3;
-    auto ini_st = createProductState<PrecisionT>("+10");
+    auto ini_st_aligned = createProductState<PrecisionT>(
+        "+10"); // Test using |+10> state using AlignedAllocator
+    std::vector<ComplexPrecisionT> ini_st{
+        ini_st_aligned.begin(),
+        ini_st_aligned
+            .end()}; // Converted aligned data to default vector alignment
 
     // Test using |+10> state
     DYNAMIC_SECTION(GateImplementation::name
@@ -493,12 +517,12 @@ void testApplyToffoli() {
         std::vector<ComplexPrecisionT> expected{
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
-            std::complex<PrecisionT>(1.0 / sqrt(2), 0),
+            std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
-            std::complex<PrecisionT>(1.0 / sqrt(2), 0)};
+            std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0)};
 
         auto sv012 = ini_st;
 
@@ -514,12 +538,12 @@ void testApplyToffoli() {
         std::vector<ComplexPrecisionT> expected{
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
-            std::complex<PrecisionT>(1.0 / sqrt(2), 0),
+            std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
-            std::complex<PrecisionT>(1.0 / sqrt(2), 0)};
+            std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0)};
 
         auto sv102 = ini_st;
 
@@ -559,8 +583,12 @@ template <typename PrecisionT, class GateImplementation> void testApplyCSWAP() {
     using ComplexPrecisionT = std::complex<PrecisionT>;
     const size_t num_qubits = 3;
 
-    auto ini_st =
-        createProductState<PrecisionT>("+10"); // Test using |+10> state
+    auto ini_st_aligned = createProductState<PrecisionT>(
+        "+10"); // Test using |+10> state using AlignedAllocator
+    std::vector<ComplexPrecisionT> ini_st{
+        ini_st_aligned.begin(),
+        ini_st_aligned
+            .end()}; // Converted aligned data to default vector alignment
 
     DYNAMIC_SECTION(GateImplementation::name
                     << ", CSWAP 0,1,2 |+10> -> |010> + |101> - "
@@ -568,10 +596,10 @@ template <typename PrecisionT, class GateImplementation> void testApplyCSWAP() {
         std::vector<ComplexPrecisionT> expected{
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
-            std::complex<PrecisionT>(1.0 / sqrt(2), 0),
+            std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
-            std::complex<PrecisionT>(1.0 / sqrt(2), 0),
+            std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>()};
 
@@ -587,8 +615,8 @@ template <typename PrecisionT, class GateImplementation> void testApplyCSWAP() {
         std::vector<ComplexPrecisionT> expected{
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
-            std::complex<PrecisionT>(1.0 / sqrt(2), 0),
-            std::complex<PrecisionT>(1.0 / sqrt(2), 0),
+            std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0),
+            std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),
             ZERO<PrecisionT>(),

--- a/pennylane_lightning/src/simulators/lightning_qubit/gates/tests/Test_KernelMap.cpp
+++ b/pennylane_lightning/src/simulators/lightning_qubit/gates/tests/Test_KernelMap.cpp
@@ -22,8 +22,8 @@ using Pennylane::Util::LightningException;
 
 TEST_CASE("Test PriorityDispatchSet", "[PriorityDispatchSet]") {
     auto pds = PriorityDispatchSet();
-    pds.emplace(10U, Util::IntegerInterval<size_t>(10, 20),
-                Gates::KernelType::PI);
+    pds.emplace(Gates::KernelType::PI, 10U,
+                Util::IntegerInterval<size_t>(10, 20));
 
     SECTION("Test conflict") {
         /* If two elements has the same priority but integer intervals overlap,

--- a/pennylane_lightning/src/simulators/lightning_qubit/gates/tests/Test_OpToMemberFuncPtr.cpp
+++ b/pennylane_lightning/src/simulators/lightning_qubit/gates/tests/Test_OpToMemberFuncPtr.cpp
@@ -1,6 +1,6 @@
 #include "Constant.hpp"
-#include "ConstantTestHelpers.hpp" // count_unique, first_elts_of, second_elts_of
-#include "ConstantUtil.hpp" // tuple_to_array, array_has_elt, prepend_to_tuple, lookup
+#include "ConstantTestHelpers.hpp" // count_unique, first_elems_of, second_elems_of
+#include "ConstantUtil.hpp" // tuple_to_array, array_has_elem, prepend_to_tuple, lookup
 #include "OpToMemberFuncPtr.hpp"
 #include "Util.hpp"
 
@@ -194,15 +194,15 @@ template <typename PrecisionT, typename ParamT, class ValueClass, size_t op_idx>
 constexpr auto opFuncPtrPairsIter() {
     if constexpr (op_idx < ValueClass::value.size()) {
         constexpr auto op = ValueClass::value[op_idx];
-        if constexpr (Util::array_has_elt(ValueClass::ignore_list, op)) {
+        if constexpr (Util::array_has_elem(ValueClass::ignore_list, op)) {
             return opFuncPtrPairsIter<PrecisionT, ParamT, ValueClass,
                                       op_idx + 1>();
         } else {
-            const auto elt = std::pair{
+            const auto elem = std::pair{
                 op, ValueClass::template func_ptr<PrecisionT, ParamT, op>};
             return Util::prepend_to_tuple(
-                elt, opFuncPtrPairsIter<PrecisionT, ParamT, ValueClass,
-                                        op_idx + 1>());
+                elem, opFuncPtrPairsIter<PrecisionT, ParamT, ValueClass,
+                                         op_idx + 1>());
         }
     } else {
         return std::tuple{};
@@ -227,13 +227,13 @@ constexpr auto gateOpFuncPtrPairsWithNumParamsIter() {
     if constexpr (tuple_idx <
                   std::tuple_size_v<
                       decltype(gate_op_func_ptr_pairs<PrecisionT, ParamT>)>) {
-        constexpr auto elt =
+        constexpr auto elem =
             std::get<tuple_idx>(gate_op_func_ptr_pairs<PrecisionT, ParamT>);
-        if constexpr (Util::lookup(Constant::gate_num_params, elt.first) ==
+        if constexpr (Util::lookup(Constant::gate_num_params, elem.first) ==
                       num_params) {
             return Util::prepend_to_tuple(
-                elt, gateOpFuncPtrPairsWithNumParamsIter<
-                         PrecisionT, ParamT, num_params, tuple_idx + 1>());
+                elem, gateOpFuncPtrPairsWithNumParamsIter<
+                          PrecisionT, ParamT, num_params, tuple_idx + 1>());
         } else {
             return gateOpFuncPtrPairsWithNumParamsIter<
                 PrecisionT, ParamT, num_params, tuple_idx + 1>();
@@ -253,8 +253,8 @@ constexpr auto generator_op_func_ptr =
 
 template <typename T, typename U, size_t size>
 auto testUniqueness(const std::array<std::pair<T, U>, size> &pairs) {
-    REQUIRE(Util::count_unique(Util::first_elts_of(pairs)) == pairs.size());
-    REQUIRE(Util::count_unique(Util::second_elts_of(pairs)) == pairs.size());
+    REQUIRE(Util::count_unique(Util::first_elems_of(pairs)) == pairs.size());
+    REQUIRE(Util::count_unique(Util::second_elems_of(pairs)) == pairs.size());
 }
 
 TEMPLATE_TEST_CASE("GateOpToMemberFuncPtr", "[GateOpToMemberFuncPtr]", float,

--- a/pennylane_lightning/src/simulators/lightning_qubit/utils/ConstantTestHelpers.hpp
+++ b/pennylane_lightning/src/simulators/lightning_qubit/utils/ConstantTestHelpers.hpp
@@ -41,12 +41,12 @@ namespace Pennylane::LightningQubit::Util {
  */
 template <typename T, typename U, size_t size>
 constexpr std::array<T, size>
-first_elts_of(const std::array<std::pair<T, U>, size> &arr) {
+first_elems_of(const std::array<std::pair<T, U>, size> &arr) {
     std::array<T, size> res = {
         T{},
     };
     std::transform(arr.begin(), arr.end(), res.begin(),
-                   [](const auto &elt) { return std::get<0>(elt); });
+                   [](const auto &elem) { return std::get<0>(elem); });
     return res;
 }
 /**
@@ -59,12 +59,12 @@ first_elts_of(const std::array<std::pair<T, U>, size> &arr) {
  */
 template <typename T, typename U, size_t size>
 constexpr std::array<U, size>
-second_elts_of(const std::array<std::pair<T, U>, size> &arr) {
+second_elems_of(const std::array<std::pair<T, U>, size> &arr) {
     std::array<U, size> res = {
         U{},
     };
     std::transform(arr.begin(), arr.end(), res.begin(),
-                   [](const auto &elt) { return std::get<1>(elt); });
+                   [](const auto &elem) { return std::get<1>(elem); });
     return res;
 }
 

--- a/pennylane_lightning/src/simulators/lightning_qubit/utils/ConstantUtil.hpp
+++ b/pennylane_lightning/src/simulators/lightning_qubit/utils/ConstantUtil.hpp
@@ -58,13 +58,13 @@ constexpr auto lookup(const std::array<std::pair<Key, Value>, size> &arr,
  * @tparam U Type of array elements.
  * @tparam size Size of array.
  * @param arr Array to check.
- * @param elt Element to find.
+ * @param elem Element to find.
  */
 template <typename U, size_t size>
-constexpr auto array_has_elt(const std::array<U, size> &arr, const U &elt)
+constexpr auto array_has_elem(const std::array<U, size> &arr, const U &elem)
     -> bool {
     for (size_t idx = 0; idx < size; idx++) {
-        if (arr[idx] == elt) {
+        if (arr[idx] == elem) {
             return true;
         }
     }
@@ -78,9 +78,9 @@ namespace Internal {
  */
 template <class T, class Tuple, std::size_t... I>
 constexpr auto
-prepend_to_tuple_helper(T &&elt, Tuple &&t,
+prepend_to_tuple_helper(T &&elem, Tuple &&t,
                         [[maybe_unused]] std::index_sequence<I...> dummy) {
-    return std::make_tuple(elt, std::get<I>(std::forward<Tuple>(t))...);
+    return std::make_tuple(elem, std::get<I>(std::forward<Tuple>(t))...);
 }
 } // namespace Internal
 /// @endcond
@@ -90,13 +90,13 @@ prepend_to_tuple_helper(T &&elt, Tuple &&t,
  * @tparam T Type of element
  * @tparam Tuple Type of the tuple (usually std::tuple)
  *
- * @param elt Element to prepend
+ * @param elem Element to prepend
  * @param t Tuple to add an element
  */
 template <class T, class Tuple>
-constexpr auto prepend_to_tuple(T &&elt, Tuple &&t) {
+constexpr auto prepend_to_tuple(T &&elem, Tuple &&t) {
     return Internal::prepend_to_tuple_helper(
-        std::forward<T>(elt), std::forward<Tuple>(t),
+        std::forward<T>(elem), std::forward<Tuple>(t),
         std::make_index_sequence<
             std::tuple_size_v<std::remove_reference_t<Tuple>>>{});
 }

--- a/pennylane_lightning/src/simulators/lightning_qubit/utils/LQubitTestHelpers.hpp
+++ b/pennylane_lightning/src/simulators/lightning_qubit/utils/LQubitTestHelpers.hpp
@@ -19,7 +19,7 @@
 
 #include "CPUMemoryModel.hpp" // getBestAllocator
 #include "Constant.hpp"
-#include "ConstantUtil.hpp" // array_has_elt, lookup
+#include "ConstantUtil.hpp" // array_has_elem, lookup
 #include "Error.hpp"
 #include "GateOperation.hpp"
 #include "LinearAlgebra.hpp" // squaredNorm
@@ -102,8 +102,8 @@ auto createPlusState(size_t num_qubits)
     TestVector<std::complex<PrecisionT>> res(
         size_t{1U} << num_qubits, {1.0, 0.0},
         getBestAllocator<std::complex<PrecisionT>>());
-    for (auto &elt : res) {
-        elt /= std::sqrt(1U << num_qubits);
+    for (auto &elem : res) {
+        elem /= std::sqrt(1U << num_qubits);
     }
     return res;
 }
@@ -151,35 +151,35 @@ auto createProductState(std::string_view str)
                                   -INVSQRT2<PrecisionT>()};
 
     for (size_t k = 0; k < (size_t{1U} << str.length()); k++) {
-        PrecisionT elt = 1.0;
+        PrecisionT elem = 1.0;
         for (size_t n = 0; n < str.length(); n++) {
             char c = str[n];
             const size_t wire = str.length() - 1 - n;
             switch (c) {
             case '0':
-                elt *= zero[(k >> wire) & 1U];
+                elem *= zero[(k >> wire) & 1U];
                 break;
             case '1':
-                elt *= one[(k >> wire) & 1U];
+                elem *= one[(k >> wire) & 1U];
                 break;
             case '+':
-                elt *= plus[(k >> wire) & 1U];
+                elem *= plus[(k >> wire) & 1U];
                 break;
             case '-':
-                elt *= minus[(k >> wire) & 1U];
+                elem *= minus[(k >> wire) & 1U];
                 break;
             default:
                 PL_ABORT("Unknown character in the argument.");
             }
         }
-        st[k] = elt;
+        st[k] = elem;
     }
     return st;
 }
 
 inline auto createWires(Gates::GateOperation op, size_t num_qubits)
     -> std::vector<size_t> {
-    if (array_has_elt(Gates::Constant::multi_qubit_gates, op)) {
+    if (array_has_elem(Gates::Constant::multi_qubit_gates, op)) {
         std::vector<size_t> wires(num_qubits);
         std::iota(wires.begin(), wires.end(), 0);
         return wires;

--- a/pennylane_lightning/src/simulators/lightning_qubit/utils/LinearAlgebra.hpp
+++ b/pennylane_lightning/src/simulators/lightning_qubit/utils/LinearAlgebra.hpp
@@ -833,8 +833,8 @@ auto randomUnitary(RandomEngine &re, size_t num_qubits)
             // orthogonalize row2
             std::transform(
                 row2_p, row2_p + dim, row1_p, row2_p,
-                [scale = dot12 / dot11](auto &elt2, const auto &elt1) {
-                    return elt2 - scale * elt1;
+                [scale = dot12 / dot11](auto &elem2, const auto &elem1) {
+                    return elem2 - scale * elem1;
                 });
         }
     }

--- a/pennylane_lightning/src/utils/Macros.hpp
+++ b/pennylane_lightning/src/utils/Macros.hpp
@@ -19,6 +19,9 @@
 #include <array>
 #include <string>
 
+#if defined(PL_USE_OMP) && !(__has_include(<omp.h>) && defined(_OPENMP))
+#undef PL_USE_OMP
+#endif
 /**
  * @brief Predefined macro variable to a string. Use std::format instead in
  * C++20.

--- a/pennylane_lightning/src/utils/TestHelpers.hpp
+++ b/pennylane_lightning/src/utils/TestHelpers.hpp
@@ -61,8 +61,8 @@ template <class T, class Alloc = std::allocator<T>> struct PLApprox {
     [[nodiscard]] std::string describe() const {
         std::ostringstream ss;
         ss << "is Approx to {";
-        for (const auto &elt : comp_) {
-            ss << elt << ", ";
+        for (const auto &elem : comp_) {
+            ss << elem << ", ";
         }
         ss << "}" << std::endl;
         return ss.str();

--- a/pennylane_lightning/src/utils/Threading.hpp
+++ b/pennylane_lightning/src/utils/Threading.hpp
@@ -22,7 +22,7 @@
 
 #include <cstdint>
 
-#ifdef PL_USE_OMP
+#if defined(PL_USE_OMP)
 #include <omp.h>
 #endif
 


### PR DESCRIPTION
… naming & structures

This PR fixes a few problems encountered with clang-tidy builds for the PR #4 

* Comparisons between data generated with different vector alignments  were adjusted to copy to the same alignment, then compare.
* Improperly defined class-level semantics, not implicitly carried over from C-structs (I moved a few structs to C++ classes and defined the appropriate CTOR/DTOR and asignment ops)
* Renamed a bunch of confusing variables (elt/elts -> elem/elems everywhere as I cannot cognitiviely accept elt as element)
* Added OpenMP to some target interfaces there were some issues mixing compiler versions and clang-tidy versions.
* Added some missing headers
* Disabled clang-tidy statements for situations where clang-tidy was unable to find anything due to some compile-time magic with the dispatcher. The linter will still be used for general purposes
* Reordered data layout for some class variables to ensure better alignment on certain systems (best to arrange data from smallest to largest to allow the option of smaller required alignment bits)
* Moved some test variables from runtime to compile-time defined.
