### PR TITLE
Update backend cpp binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,27 +93,27 @@ target_include_directories(pennylane_lightning  INTERFACE "$<INSTALL_INTERFACE:$
 
 if(ENABLE_PYTHON)
     message(STATUS "ENABLE_PYTHON is ON.")
-    pybind11_add_module(pennylane_lightning_ops "pennylane_lightning/src/bindings/Bindings.cpp")
+    pybind11_add_module("${PL_BACKEND}_ops" "pennylane_lightning/src/bindings/Bindings.cpp")
 
-    target_link_libraries(pennylane_lightning_ops PRIVATE   lightning_compile_options
+    target_link_libraries("${PL_BACKEND}_ops" PRIVATE   lightning_compile_options
                                                             lightning_external_libs
                                                             )
 
-    target_link_libraries(pennylane_lightning_ops PRIVATE   lightning_observables
+    target_link_libraries("${PL_BACKEND}_ops" PRIVATE   lightning_observables
                                                             lightning_utils
                                                             lightning_algorithms
                                                             )
 
-    target_link_libraries(pennylane_lightning_ops PRIVATE   ${PL_BACKEND} #simulator
+    target_link_libraries("${PL_BACKEND}_ops" PRIVATE   ${PL_BACKEND} #simulator
                                                             "${PL_BACKEND}_algorithms"
                                                             "${PL_BACKEND}_observables"
                                                             "${PL_BACKEND}_bindings"
                                                             "${PL_BACKEND}_measurements"
                                                             )
 
-    set_target_properties(pennylane_lightning_ops PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    set_target_properties("${PL_BACKEND}_ops" PROPERTIES CXX_VISIBILITY_PRESET hidden)
 
-    target_compile_definitions(pennylane_lightning_ops PRIVATE VERSION_INFO=${VERSION_STRING})
+    target_compile_definitions("${PL_BACKEND}_ops" PRIVATE VERSION_INFO=${VERSION_STRING})
 endif()
 
 install(TARGETS pennylane_lightning

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ help:
 clean:
 	find . -type d -name '__pycache__' -exec rm -r {} \+
 	rm -rf build Build BuildTests BuildTidy BuildGBench
-	rm -rf pennylane_lightning/pennylane_lightning_ops*
+	rm -rf pennylane_lightning/*_ops*
 
 test-builtin:
 	$(PYTHON) -I $(TESTRUNNER)

--- a/pennylane_lightning/__init__.py
+++ b/pennylane_lightning/__init__.py
@@ -15,14 +15,5 @@
 
 from ._version import __version__
 
-from .lightning_base import CPP_BINARY_AVAILABLE, backend_info
-
-if CPP_BINARY_AVAILABLE:
-    if backend_info()["NAME"] == "lightning.kokkos":
-        from .lightning_kokkos import LightningKokkos
-    elif backend_info()["NAME"] == "lightning.qubit":
-        from .lightning_qubit import LightningQubit
-    else:
-        ValueError(f"Invalid backend name: {backend_info()['NAME']}")
-else:
-    from .lightning_qubit import LightningQubit
+from .lightning_kokkos import LightningKokkos
+from .lightning_qubit import LightningQubit

--- a/pennylane_lightning/_serialize.py
+++ b/pennylane_lightning/_serialize.py
@@ -15,7 +15,6 @@ r"""
 Helper functions for serializing quantum tapes.
 """
 from typing import List, Tuple
-
 import numpy as np
 from pennylane import (
     BasisState,
@@ -31,24 +30,7 @@ from pennylane.operation import Tensor
 from pennylane.tape import QuantumTape
 from pennylane.math import unwrap
 
-from pennylane import matrix
-
-try:
-    from .pennylane_lightning_ops import (
-        StateVectorC128,
-    )
-    from .pennylane_lightning_ops.observables import (
-        NamedObsC64,
-        NamedObsC128,
-        HermitianObsC64,
-        HermitianObsC128,
-        TensorProdObsC64,
-        TensorProdObsC128,
-        HamiltonianC64,
-        HamiltonianC128,
-    )
-except ImportError:
-    pass
+from pennylane import matrix, DeviceError
 
 pauli_name_map = {
     "I": "Identity",
@@ -58,162 +40,210 @@ pauli_name_map = {
 }
 
 
-def _serialize_named_obs(ob, wires_map: dict, use_csingle: bool):
-    """Serializes a Named observable"""
-    named_obs = NamedObsC64 if use_csingle else NamedObsC128
-    wires = [wires_map[w] for w in ob.wires]
-    if ob.name == "Identity":
-        wires = wires[:1]
-    return named_obs(ob.name, wires)
-
-
-def _serialize_hermitian_ob(o, wires_map: dict, use_csingle: bool):
-    """Serializes a Hermitian observable"""
-    assert not isinstance(o, Tensor)
-
-    if use_csingle:
-        ctype = np.complex64
-        hermitian_obs = HermitianObsC64
-    else:
-        ctype = np.complex128
-        hermitian_obs = HermitianObsC128
-
-    wires = [wires_map[w] for w in o.wires]
-    return hermitian_obs(matrix(o).ravel().astype(ctype), wires)
-
-
-def _serialize_tensor_ob(ob, wires_map: dict, use_csingle: bool):
-    """Serialize a tensor observable"""
-    assert isinstance(ob, Tensor)
-
-    if use_csingle:
-        tensor_obs = TensorProdObsC64
-    else:
-        tensor_obs = TensorProdObsC128
-
-    return tensor_obs([_serialize_ob(o, wires_map, use_csingle) for o in ob.obs])
-
-
-def _serialize_hamiltonian(ob, wires_map: dict, use_csingle: bool):
-    if use_csingle:
-        rtype = np.float32
-        hamiltonian_obs = HamiltonianC64
-    else:
-        rtype = np.float64
-        hamiltonian_obs = HamiltonianC128
-
-    coeffs = np.array(unwrap(ob.coeffs)).astype(rtype)
-    terms = [_serialize_ob(t, wires_map, use_csingle) for t in ob.ops]
-    return hamiltonian_obs(coeffs, terms)
-
-
-def _serialize_pauli_word(ob, wires_map: dict, use_csingle: bool):
-    """Serialize a :class:`pennylane.pauli.PauliWord` into a Named or Tensor observable."""
-    if use_csingle:
-        named_obs = NamedObsC64
-        tensor_obs = TensorProdObsC64
-    else:
-        named_obs = NamedObsC128
-        tensor_obs = TensorProdObsC128
-
-    if len(ob) == 1:
-        wire, pauli = list(ob.items())[0]
-        return named_obs(pauli_name_map[pauli], [wires_map[wire]])
-
-    return tensor_obs(
-        [named_obs(pauli_name_map[pauli], [wires_map[wire]]) for wire, pauli in ob.items()]
-    )
-
-
-def _serialize_pauli_sentence(ob, wires_map: dict, use_csingle: bool):
-    """Serialize a :class:`pennylane.pauli.PauliSentence` into a Hamiltonian."""
-    if use_csingle:
-        rtype = np.float32
-        hamiltonian_obs = HamiltonianC64
-    else:
-        rtype = np.float64
-        hamiltonian_obs = HamiltonianC128
-
-    pwords, coeffs = zip(*ob.items())
-    terms = [_serialize_pauli_word(pw, wires_map, use_csingle) for pw in pwords]
-    coeffs = np.array(coeffs).astype(rtype)
-    return hamiltonian_obs(coeffs, terms)
-
-
-def _serialize_ob(ob, wires_map, use_csingle):
-    """Serialize a :class:`pennylane.operation.Observable` into an Observable."""
-    if isinstance(ob, Tensor):
-        return _serialize_tensor_ob(ob, wires_map, use_csingle)
-    if ob.name == "Hamiltonian":
-        return _serialize_hamiltonian(ob, wires_map, use_csingle)
-    if isinstance(ob, (PauliX, PauliY, PauliZ, Identity, Hadamard)):
-        return _serialize_named_obs(ob, wires_map, use_csingle)
-    if ob._pauli_rep is not None:
-        return _serialize_pauli_sentence(ob._pauli_rep, wires_map, use_csingle)
-    return _serialize_hermitian_ob(ob, wires_map, use_csingle)
-
-
-def _serialize_observables(tape: QuantumTape, wires_map: dict, use_csingle: bool = False) -> List:
-    """Serializes the observables of an input tape.
-
-    Args:
-        tape (QuantumTape): the input quantum tape
-        wires_map (dict): a dictionary mapping input wires to the device's backend wires
-        use_csingle (bool): whether to use np.complex64 instead of np.complex128
-
-    Returns:
-        list(ObsStructC128 or ObsStructC64): A list of observable objects compatible with the C++ backend
-    """
-
-    return [_serialize_ob(ob, wires_map, use_csingle) for ob in tape.observables]
-
-
-def _serialize_ops(
-    tape: QuantumTape, wires_map: dict
-) -> Tuple[List[List[str]], List[np.ndarray], List[List[int]], List[bool], List[np.ndarray]]:
-    """Serializes the operations of an input tape.
-
-    The state preparation operations are not included.
-
-    Args:
-        tape (QuantumTape): the input quantum tape
-        wires_map (dict): a dictionary mapping input wires to the device's backend wires
-
-    Returns:
-        Tuple[list, list, list, list, list]: A serialization of the operations, containing a list
-        of operation names, a list of operation parameters, a list of observable wires, a list of
-        inverses, and a list of matrices for the operations that do not have a dedicated kernel.
-    """
-    names = []
-    params = []
-    wires = []
-    mats = []
-
-    uses_stateprep = False
-
-    for o in tape.operations:
-        if isinstance(o, (BasisState, QubitStateVector)):
-            uses_stateprep = True
-            continue
-        elif isinstance(o, Rot):
-            op_list = o.expand().operations
+class _Serialize:
+    def __init__(self, device_name):
+        if device_name == "lightning.qubit":
+            try:
+                from .lightning_qubit_ops import (
+                    StateVectorC128,
+                )
+                from .lightning_qubit_ops.observables import (
+                    NamedObsC64,
+                    NamedObsC128,
+                    HermitianObsC64,
+                    HermitianObsC128,
+                    TensorProdObsC64,
+                    TensorProdObsC128,
+                    HamiltonianC64,
+                    HamiltonianC128,
+                )
+            except ImportError:
+                raise ImportError(
+                    "Pre-compiled binaries for "
+                    + device_name
+                    + " serialize functionality are not available."
+                )
+        elif device_name == "lightning.kokkos":
+            try:
+                from .lightning_kokkos_ops import (
+                    StateVectorC128,
+                )
+                from .lightning_kokkos_ops.observables import (
+                    NamedObsC64,
+                    NamedObsC128,
+                    HermitianObsC64,
+                    HermitianObsC128,
+                    TensorProdObsC64,
+                    TensorProdObsC128,
+                    HamiltonianC64,
+                    HamiltonianC128,
+                )
+            except ImportError:
+                raise ImportError(
+                    "Pre-compiled binaries for "
+                    + device_name
+                    + " serialize functionality are not available."
+                )
         else:
-            op_list = [o]
+            raise DeviceError('The device name "' + device_name + '" is not a valid option.')
+        self.StateVectorC128 = StateVectorC128
+        self.NamedObsC64 = NamedObsC64
+        self.NamedObsC128 = NamedObsC128
+        self.HermitianObsC64 = HermitianObsC64
+        self.HermitianObsC128 = HermitianObsC128
+        self.TensorProdObsC64 = TensorProdObsC64
+        self.TensorProdObsC128 = TensorProdObsC128
+        self.HamiltonianC64 = HamiltonianC64
+        self.HamiltonianC128 = HamiltonianC128
 
-        for single_op in op_list:
-            name = single_op.name
-            names.append(name)
+    def _named_obs(self, ob, wires_map: dict, use_csingle: bool):
+        """Serializes a Named observable"""
+        named_obs = self.NamedObsC64 if use_csingle else self.NamedObsC128
+        wires = [wires_map[w] for w in ob.wires]
+        if ob.name == "Identity":
+            wires = wires[:1]
+        return named_obs(ob.name, wires)
 
-            if not hasattr(StateVectorC128, name):
-                params.append([])
-                mats.append(matrix(single_op))
+    def _hermitian_ob(self, o, wires_map: dict, use_csingle: bool):
+        """Serializes a Hermitian observable"""
+        assert not isinstance(o, Tensor)
 
+        if use_csingle:
+            ctype = np.complex64
+            hermitian_obs = self.HermitianObsC64
+        else:
+            ctype = np.complex128
+            hermitian_obs = self.HermitianObsC128
+
+        wires = [wires_map[w] for w in o.wires]
+        return hermitian_obs(matrix(o).ravel().astype(ctype), wires)
+
+    def _tensor_ob(self, ob, wires_map: dict, use_csingle: bool):
+        """Serialize a tensor observable"""
+        assert isinstance(ob, Tensor)
+
+        if use_csingle:
+            tensor_obs = self.TensorProdObsC64
+        else:
+            tensor_obs = self.TensorProdObsC128
+
+        return tensor_obs([self._ob(o, wires_map, use_csingle) for o in ob.obs])
+
+    def _hamiltonian(self, ob, wires_map: dict, use_csingle: bool):
+        if use_csingle:
+            rtype = np.float32
+            hamiltonian_obs = self.HamiltonianC64
+        else:
+            rtype = np.float64
+            hamiltonian_obs = self.HamiltonianC128
+
+        coeffs = np.array(unwrap(ob.coeffs)).astype(rtype)
+        terms = [self._ob(t, wires_map, use_csingle) for t in ob.ops]
+        return hamiltonian_obs(coeffs, terms)
+
+    def _pauli_word(self, ob, wires_map: dict, use_csingle: bool):
+        """Serialize a :class:`pennylane.pauli.PauliWord` into a Named or Tensor observable."""
+        if use_csingle:
+            named_obs = self.NamedObsC64
+            tensor_obs = self.TensorProdObsC64
+        else:
+            named_obs = self.NamedObsC128
+            tensor_obs = self.TensorProdObsC128
+
+        if len(ob) == 1:
+            wire, pauli = list(ob.items())[0]
+            return named_obs(pauli_name_map[pauli], [wires_map[wire]])
+
+        return tensor_obs(
+            [named_obs(pauli_name_map[pauli], [wires_map[wire]]) for wire, pauli in ob.items()]
+        )
+
+    def _pauli_sentence(self, ob, wires_map: dict, use_csingle: bool):
+        """Serialize a :class:`pennylane.pauli.PauliSentence` into a Hamiltonian."""
+        if use_csingle:
+            rtype = np.float32
+            hamiltonian_obs = self.HamiltonianC64
+        else:
+            rtype = np.float64
+            hamiltonian_obs = self.HamiltonianC128
+
+        pwords, coeffs = zip(*ob.items())
+        terms = [self._pauli_word(pw, wires_map, use_csingle) for pw in pwords]
+        coeffs = np.array(coeffs).astype(rtype)
+        return hamiltonian_obs(coeffs, terms)
+
+    def _ob(self, ob, wires_map, use_csingle):
+        """Serialize a :class:`pennylane.operation.Observable` into an Observable."""
+        if isinstance(ob, Tensor):
+            return self._tensor_ob(ob, wires_map, use_csingle)
+        if ob.name == "Hamiltonian":
+            return self._hamiltonian(ob, wires_map, use_csingle)
+        if isinstance(ob, (PauliX, PauliY, PauliZ, Identity, Hadamard)):
+            return self._named_obs(ob, wires_map, use_csingle)
+        if ob._pauli_rep is not None:
+            return self._pauli_sentence(ob._pauli_rep, wires_map, use_csingle)
+        return self._hermitian_ob(ob, wires_map, use_csingle)
+
+    def _observables(self, tape: QuantumTape, wires_map: dict, use_csingle: bool = False) -> List:
+        """Serializes the observables of an input tape.
+
+        Args:
+            tape (QuantumTape): the input quantum tape
+            wires_map (dict): a dictionary mapping input wires to the device's backend wires
+            use_csingle (bool): whether to use np.complex64 instead of np.complex128
+
+        Returns:
+            list(ObsStructC128 or ObsStructC64): A list of observable objects compatible with the C++ backend
+        """
+
+        return [self._ob(ob, wires_map, use_csingle) for ob in tape.observables]
+
+    def _ops(
+        self, tape: QuantumTape, wires_map: dict
+    ) -> Tuple[List[List[str]], List[np.ndarray], List[List[int]], List[bool], List[np.ndarray]]:
+        """Serializes the operations of an input tape.
+
+        The state preparation operations are not included.
+
+        Args:
+            tape (QuantumTape): the input quantum tape
+            wires_map (dict): a dictionary mapping input wires to the device's backend wires
+
+        Returns:
+            Tuple[list, list, list, list, list]: A serialization of the operations, containing a list
+            of operation names, a list of operation parameters, a list of observable wires, a list of
+            inverses, and a list of matrices for the operations that do not have a dedicated kernel.
+        """
+        names = []
+        params = []
+        wires = []
+        mats = []
+
+        uses_stateprep = False
+
+        for o in tape.operations:
+            if isinstance(o, (BasisState, QubitStateVector)):
+                uses_stateprep = True
+                continue
+            elif isinstance(o, Rot):
+                op_list = o.expand().operations
             else:
-                params.append(single_op.parameters)
-                mats.append([])
+                op_list = [o]
 
-            wires_list = single_op.wires.tolist()
-            wires.append([wires_map[w] for w in wires_list])
+            for single_op in op_list:
+                name = single_op.name
+                names.append(name)
 
-    inverses = [False] * len(names)
-    return (names, params, wires, inverses, mats), uses_stateprep
+                if not hasattr(self.StateVectorC128, name):
+                    params.append([])
+                    mats.append(matrix(single_op))
+
+                else:
+                    params.append(single_op.parameters)
+                    mats.append([])
+
+                wires_list = single_op.wires.tolist()
+                wires.append([wires_map[w] for w in wires_list])
+
+        inverses = [False] * len(names)
+        return (names, params, wires, inverses, mats), uses_stateprep

--- a/pennylane_lightning/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos.py
@@ -19,9 +19,28 @@ interfaces with C++ for fast linear algebra calculations.
 from warnings import warn
 import numpy as np
 
-from .lightning_base import backend_info, LightningBase, _chunk_iterable
+from .lightning_base import LightningBase, LightningBaseFallBack, _chunk_iterable
 
-if backend_info()["NAME"] == "lightning.kokkos":
+try:
+    # pylint: disable=import-error, no-name-in-module
+    from .lightning_kokkos_ops import (
+        allocate_aligned_array,
+        get_alignment,
+        best_alignment,
+        InitializationSettings,
+        print_configuration,
+        MeasurementsC64,
+        StateVectorC64,
+        MeasurementsC128,
+        StateVectorC128,
+        backend_info,
+    )
+
+    LK_CPP_BINARY_AVAILABLE = True
+except:
+    LK_CPP_BINARY_AVAILABLE = False
+
+if LK_CPP_BINARY_AVAILABLE:
     from typing import List
     from os import getenv
 
@@ -44,27 +63,14 @@ if backend_info()["NAME"] == "lightning.kokkos":
     from ._version import __version__
 
     # pylint: disable=import-error, no-name-in-module
-    from .pennylane_lightning_ops import (
-        allocate_aligned_array,
-        get_alignment,
-        best_alignment,
-        InitializationSettings,
-        print_configuration,
-        MeasurementsC64,
-        StateVectorC64,
-        MeasurementsC128,
-        StateVectorC128,
-    )
-
-    # pylint: disable=import-error, no-name-in-module
-    from .pennylane_lightning_ops.algorithms import (
+    from .lightning_kokkos_ops.algorithms import (
         AdjointJacobianC64,
         create_ops_listC64,
         AdjointJacobianC128,
         create_ops_listC128,
     )
 
-    from ._serialize import _serialize_ob
+    from ._serialize import _Serialize
 
     def _kokkos_dtype(dtype):
         if dtype not in [np.complex128, np.complex64]:
@@ -174,6 +180,7 @@ if backend_info()["NAME"] == "lightning.kokkos":
         kokkos_config = {}
         operations = allowed_operations
         observables = allowed_observables
+        _backend_info = backend_info
 
         def __init__(
             self,
@@ -477,7 +484,7 @@ if backend_info()["NAME"] == "lightning.kokkos":
                 or (observable.arithmetic_depth > 0)
                 or isinstance(observable.name, List)
             ):
-                ob_serialized = _serialize_ob(
+                ob_serialized = _Serialize(self.short_name)._ob(
                     observable, self.wire_map, use_csingle=self.use_csingle
                 )
                 return measure.expval(ob_serialized)
@@ -508,7 +515,7 @@ if backend_info()["NAME"] == "lightning.kokkos":
 
             if self.shots is not None:
                 # estimate the var
-                # LightningQubit doesn't support sampling yet
+                # LightningKokkos doesn't support sampling yet
                 samples = self.sample(observable, shot_range=shot_range, bin_size=bin_size)
                 return np.squeeze(np.var(samples, axis=0))
 
@@ -532,7 +539,7 @@ if backend_info()["NAME"] == "lightning.kokkos":
                 or (observable.arithmetic_depth > 0)
                 or isinstance(observable.name, List)
             ):
-                ob_serialized = _serialize_ob(
+                ob_serialized = _Serialize(self.short_name)._ob(
                     observable, self.wire_map, use_csingle=self.use_csingle
                 )
                 return measure.var(ob_serialized)
@@ -791,7 +798,7 @@ if backend_info()["NAME"] == "lightning.kokkos":
 
 else:
 
-    class LightningKokkos(LightningBase):  # pragma: no cover
+    class LightningKokkos(LightningBaseFallBack):  # pragma: no cover
         # pylint: disable=missing-class-docstring
         name = "Lightning Kokkos PennyLane plugin [No binaries found - Fallback: default.qubit]"
         short_name = "lightning.kokkos"

--- a/pennylane_lightning/src/bindings/Bindings.cpp
+++ b/pennylane_lightning/src/bindings/Bindings.cpp
@@ -19,8 +19,14 @@
 
 #include "pybind11/pybind11.h"
 
-#if defined(_ENABLE_PLQUBIT) || _ENABLE_PLKOKKOS == 1
+// Defining the module name.
+#if defined(_ENABLE_PLQUBIT)
+#define pennylane_lightning_ops lightning_qubit_ops
+#elif _ENABLE_PLKOKKOS == 1
+#define pennylane_lightning_ops lightning_kokkos_ops
+#endif
 
+#if defined(pennylane_lightning_ops)
 /// @cond DEV
 namespace {
 using namespace Pennylane;

--- a/pennylane_lightning/src/simulators/lightning_kokkos/bindings/LKokkosBindings.hpp
+++ b/pennylane_lightning/src/simulators/lightning_kokkos/bindings/LKokkosBindings.hpp
@@ -185,7 +185,7 @@ void registerBackendClassSpecificBindings(PyClass &pyclass) {
                     conv_matrix = std::vector<Kokkos::complex<ParamT>>{
                         m_ptr, m_ptr + m_buffer.size};
                 }
-                sv.applyOperation_std(str, wires, inv, std::vector<ParamT>{},
+                sv.applyOperation(str, wires, inv, std::vector<ParamT>{},
                                       conv_matrix);
             },
             "Apply operation via the gate matrix");

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,6 @@ class CMakeBuild(build_ext):
             env=os.environ,
         )
 
-
 with open(os.path.join("pennylane_lightning", "_version.py")) as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
 
@@ -157,7 +156,7 @@ requirements = [
 suffix = backend.replace("lightning_","")
 suffix = suffix[0].upper() + suffix[1:]
 pennylane_plugins = [f"{device_name} = pennylane_lightning:Lightning{suffix}"]
-    
+
 info = {
     "name": "PennyLane-Lightning",
     "version": version,
@@ -183,7 +182,7 @@ info = {
     "install_requires": requirements,
     "ext_modules": []
     if os.environ.get("SKIP_COMPILATION", False)
-    else [CMakeExtension("pennylane_lightning_ops")],
+    else [CMakeExtension(backend+"_ops")],
     "cmdclass": {"build_ext": CMakeBuild},
     "ext_package": "pennylane_lightning",
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,6 @@ import pytest
 import numpy as np
 
 import pennylane as qml
-from pennylane_lightning.lightning_base import backend_info
 
 # defaults
 TOL = 1e-6
@@ -85,17 +84,24 @@ def n_subsystems(request):
     return request.param
 
 
-# Device specification:
+# Device specification
 # The device name will be provided by the binaries.
-device_name = backend_info()["NAME"]
+# Checking binaries:
+try:
+    from pennylane_lightning.lightning_qubit_ops import backend_info
+except ModuleNotFoundError:
+    try:
+        from pennylane_lightning.lightning_kokkos_ops import backend_info
+    except ModuleNotFoundError:
+        # with no binaries we fallback to LightningQubit, and this one will fallback to default.
+        from pennylane_lightning import LightningQubit as LightningDevice
+    else:
+        from pennylane_lightning import LightningKokkos as LightningDevice
 
-if device_name == "lightning.kokkos":
-    from pennylane_lightning import LightningKokkos as LightningDevice
-elif device_name == "lightning.qubit":
-    from pennylane_lightning import LightningQubit as LightningDevice
 else:
-    device_name = "lightning.qubit"
     from pennylane_lightning import LightningQubit as LightningDevice
+
+device_name = LightningDevice.short_name
 
 
 # General qubit_device fixture, for any number of wires.

--- a/tests/lightning_qubit/test_measurements_samples_MCMC.py
+++ b/tests/lightning_qubit/test_measurements_samples_MCMC.py
@@ -14,17 +14,21 @@
 """
 Unit tests for MCMC sampling in lightning.qubit.
 """
+import pytest
+from conftest import LightningDevice  # tested device
+
 import numpy as np
 import pennylane as qml
 
 import pytest
 
-from pennylane_lightning import CPP_BINARY_AVAILABLE, backend_info
+from pennylane_lightning import LightningQubit
 
-if not CPP_BINARY_AVAILABLE:
+
+if not LightningQubit._CPP_BINARY_AVAILABLE:
     pytest.skip("No binary module found. Skipping.", allow_module_level=True)
 
-if backend_info()["NAME"] != "lightning.qubit":
+if LightningDevice != LightningQubit:
     pytest.skip("Exclusive tests for lightning.qubit. Skipping.", allow_module_level=True)
 
 

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -15,15 +15,13 @@
 Tests for ``adjoint_jacobian`` method on Lightning devices.
 """
 import pytest
+from conftest import device_name, LightningDevice as ld
 
 import math
 from scipy.stats import unitary_group
-
 import pennylane as qml
 from pennylane import numpy as np
 from pennylane import QNode, qnode
-
-from conftest import device_name, LightningDevice as ld
 
 I, X, Y, Z = (
     np.eye(2),

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -16,24 +16,18 @@ Unit tests for Lightning devices.
 """
 # pylint: disable=protected-access,cell-var-from-loop
 import pytest
+from conftest import THETA, PHI, VARPHI, TOL_STOCHASTIC, LightningDevice as ld, device_name
 
 import math
 import numpy as np
-
 import pennylane as qml
 from pennylane import DeviceError
-
-from pennylane_lightning import CPP_BINARY_AVAILABLE
-
-from conftest import THETA, PHI, VARPHI, TOL_STOCHASTIC, LightningDevice, device_name
 
 
 class TestApply:
     """Tests that operations of certain operations are applied correctly or
     that the proper errors are raised.
     """
-
-    ld = LightningDevice
 
     test_data_no_parameters = [
         (qml.PauliX, [1, 0], np.array([0, 1])),
@@ -666,7 +660,7 @@ class TestLightningDeviceIntegration:
         assert dev.shots is None
         assert dev.short_name == device_name
 
-    @pytest.mark.skipif(not CPP_BINARY_AVAILABLE, reason="Lightning binary required")
+    @pytest.mark.skipif(not ld._CPP_BINARY_AVAILABLE, reason="Lightning binary required")
     def test_no_backprop(self):
         """Test that lightning device does not support the backprop
         differentiation method."""
@@ -680,7 +674,7 @@ class TestLightningDeviceIntegration:
         with pytest.raises(qml.QuantumFunctionError):
             qml.QNode(circuit, dev, diff_method="backprop")
 
-    @pytest.mark.skipif(not CPP_BINARY_AVAILABLE, reason="Lightning binary required")
+    @pytest.mark.skipif(not ld._CPP_BINARY_AVAILABLE, reason="Lightning binary required")
     def test_best_gets_lightning(self):
         """Test that the best differentiation method returns lightning
         qubit."""
@@ -691,7 +685,7 @@ class TestLightningDeviceIntegration:
             return qml.expval(qml.PauliZ(0))
 
         qnode = qml.QNode(circuit, dev, diff_method="best")
-        assert isinstance(qnode.device, LightningDevice)
+        assert isinstance(qnode.device, ld)
 
     def test_args(self):
         """Test that the plugin requires correct arguments"""
@@ -1458,7 +1452,9 @@ class TestApplyLightningMethod:
         assert dev.state.dtype == dev.C_DTYPE
 
 
-@pytest.mark.skipif(CPP_BINARY_AVAILABLE, reason="Test only applies when binaries are unavailable")
+@pytest.mark.skipif(
+    ld._CPP_BINARY_AVAILABLE, reason="Test only applies when binaries are unavailable"
+)
 def test_warning():
     """Tests if a warning is raised when lightning device binaries are not available"""
     with pytest.warns(UserWarning, match="Pre-compiled binaries for lightning.qubit"):

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -15,18 +15,20 @@
 Array tests for Lightning devices.
 """
 import pytest
+from conftest import LightningDevice as ld
 
 import numpy as np
 
-from pennylane_lightning import CPP_BINARY_AVAILABLE
-
 try:
-    from pennylane_lightning.pennylane_lightning_ops import allocate_aligned_array
+    from pennylane_lightning.lightning_qubit_ops import allocate_aligned_array
 except (ImportError, ModuleNotFoundError):
-    pytest.skip("No binary module found. Skipping.", allow_module_level=True)
+    try:
+        from pennylane_lightning.lightning_kokkos_ops import allocate_aligned_array
+    except (ImportError, ModuleNotFoundError):
+        pytest.skip("No binary module found. Skipping.", allow_module_level=True)
 
 
-@pytest.mark.skipif(not CPP_BINARY_AVAILABLE, reason="Lightning binary required")
+@pytest.mark.skipif(not ld._CPP_BINARY_AVAILABLE, reason="Lightning binary required")
 @pytest.mark.parametrize("dt", [np.dtype(np.complex64), np.dtype(np.complex128)])
 def test_allocate_aligned_array(dt):
     arr = allocate_aligned_array(1024, dt)

--- a/tests/test_binary_info.py
+++ b/tests/test_binary_info.py
@@ -21,9 +21,12 @@ if platform.machine() != "x86_64":
     pytest.skip("Expected to fail on non x86 systems. Skipping.", allow_module_level=True)
 
 try:
-    from pennylane_lightning.pennylane_lightning_ops import runtime_info, compile_info
+    from pennylane_lightning.lightning_qubit_ops import runtime_info, compile_info
 except (ImportError, ModuleNotFoundError):
-    pytest.skip("No binary module found. Skipping.", allow_module_level=True)
+    try:
+        from pennylane_lightning.lightning_kokkos_ops import runtime_info, compile_info
+    except (ImportError, ModuleNotFoundError):
+        pytest.skip("No binary module found. Skipping.", allow_module_level=True)
 
 
 def test_runtime_info():

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -16,15 +16,12 @@ Integration tests that compare the output states of the
 compiled Lightning device with the ``default.qubit``.
 """
 import pytest
+from conftest import device_name, LightningDevice as ld
 
 import itertools
 import numpy as np
 import os
-
 import pennylane as qml
-from pennylane_lightning import CPP_BINARY_AVAILABLE
-
-from conftest import device_name
 
 
 def lightning_backend_dev(wires):
@@ -67,7 +64,7 @@ class TestComparison:
     @pytest.mark.parametrize(
         "lightning_dev_version", [lightning_backend_dev, lightning_backend_batch_obs_dev]
     )
-    @pytest.mark.skipif(not CPP_BINARY_AVAILABLE, reason="Lightning binary required")
+    @pytest.mark.skipif(not ld._CPP_BINARY_AVAILABLE, reason="Lightning binary required")
     @pytest.mark.parametrize("num_threads", [1, 2])
     def test_one_qubit_circuit(
         self, monkeypatch, wires, lightning_dev_version, basis_state, num_threads
@@ -104,7 +101,7 @@ class TestComparison:
         "lightning_dev_version", [lightning_backend_dev, lightning_backend_batch_obs_dev]
     )
     @pytest.mark.parametrize("num_threads", [1, 2])
-    @pytest.mark.skipif(not CPP_BINARY_AVAILABLE, reason="Lightning binary required")
+    @pytest.mark.skipif(not ld._CPP_BINARY_AVAILABLE, reason="Lightning binary required")
     def test_two_qubit_circuit(
         self, monkeypatch, wires, lightning_dev_version, basis_state, num_threads
     ):
@@ -148,7 +145,7 @@ class TestComparison:
         "lightning_dev_version", [lightning_backend_dev, lightning_backend_batch_obs_dev]
     )
     @pytest.mark.parametrize("num_threads", [1, 2])
-    @pytest.mark.skipif(not CPP_BINARY_AVAILABLE, reason="Lightning binary required")
+    @pytest.mark.skipif(not ld._CPP_BINARY_AVAILABLE, reason="Lightning binary required")
     def test_three_qubit_circuit(
         self, monkeypatch, wires, lightning_dev_version, basis_state, num_threads
     ):
@@ -200,7 +197,7 @@ class TestComparison:
         "lightning_dev_version", [lightning_backend_dev, lightning_backend_batch_obs_dev]
     )
     @pytest.mark.parametrize("num_threads", [1, 2])
-    @pytest.mark.skipif(not CPP_BINARY_AVAILABLE, reason="Lightning binary required")
+    @pytest.mark.skipif(not ld._CPP_BINARY_AVAILABLE, reason="Lightning binary required")
     def test_four_qubit_circuit(
         self, monkeypatch, wires, lightning_dev_version, basis_state, num_threads
     ):
@@ -256,7 +253,7 @@ class TestComparison:
     )
     @pytest.mark.parametrize("wires", range(1, 17))
     @pytest.mark.parametrize("num_threads", [1, 2])
-    @pytest.mark.skipif(not CPP_BINARY_AVAILABLE, reason="Lightning binary required")
+    @pytest.mark.skipif(not ld._CPP_BINARY_AVAILABLE, reason="Lightning binary required")
     def test_n_qubit_circuit(self, monkeypatch, wires, lightning_dev_version, num_threads):
         """Test an n-qubit circuit"""
         monkeypatch.setenv("OMP_NUM_THREADS", str(num_threads))

--- a/tests/test_decomposition.py
+++ b/tests/test_decomposition.py
@@ -15,15 +15,12 @@
 Unit tests for operation decomposition with Lightning devices.
 """
 import pytest
+from conftest import LightningDevice as ld
 
 import numpy as np
-
 import pennylane as qml
-from pennylane_lightning import CPP_BINARY_AVAILABLE
 
-from conftest import LightningDevice
-
-if not CPP_BINARY_AVAILABLE:
+if not ld._CPP_BINARY_AVAILABLE:
     pytest.skip("No binary module found. Skipping.", allow_module_level=True)
 
 
@@ -42,4 +39,4 @@ class TestDenseMatrixDecompositionThreshold:
     def test_threshold(self, op, n_wires, condition):
         wires = np.linspace(0, n_wires - 1, n_wires, dtype=int)
         op = op(wires=wires)
-        assert LightningDevice.stopping_condition.__get__(op)(op) == condition
+        assert ld.stopping_condition.__get__(op)(op) == condition

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -15,15 +15,12 @@
 Unit tests for Lightning devices creation.
 """
 import pytest
+from conftest import device_name, LightningDevice as ld
 
 import numpy as np
-
 import pennylane as qml
-from pennylane_lightning import CPP_BINARY_AVAILABLE
 
-from conftest import device_name
-
-if not CPP_BINARY_AVAILABLE:
+if not ld._CPP_BINARY_AVAILABLE:
     pytest.skip("No binary module found. Skipping.", allow_module_level=True)
 
 

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -15,11 +15,10 @@
 Integration tests for the ``execute`` method of Lightning devices.
 """
 import pytest
+from conftest import device_name
 
 import pennylane as qml
 from pennylane import numpy as np
-
-from conftest import device_name
 
 
 @pytest.mark.parametrize("diff_method", ("param_shift", "finite_diff"))

--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -15,11 +15,10 @@
 Unit tests for the expval method of Lightning devices.
 """
 import pytest
+from conftest import THETA, PHI, VARPHI
 
 import numpy as np
 import pennylane as qml
-
-from conftest import THETA, PHI, VARPHI
 
 
 @pytest.mark.parametrize("theta, phi", list(zip(THETA, PHI)))

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -15,13 +15,11 @@
 Unit tests for the correct application of gates with a Lightning device.
 """
 import pytest
+from conftest import LightningDevice, device_name
 
 import itertools
 import numpy as np
-
 import pennylane as qml
-
-from conftest import LightningDevice, device_name
 
 
 @pytest.fixture

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -15,6 +15,7 @@
 Unit tests for Measurements in Lightning devices.
 """
 import pytest
+from conftest import device_name, LightningDevice as ld
 
 import numpy as np
 import math
@@ -24,11 +25,8 @@ from pennylane.measurements import (
     Variance,
     Expectation,
 )
-from pennylane_lightning import CPP_BINARY_AVAILABLE
 
-from conftest import device_name
-
-if not CPP_BINARY_AVAILABLE:
+if not ld._CPP_BINARY_AVAILABLE:
     pytest.skip("No binary module found. Skipping.", allow_module_level=True)
 
 

--- a/tests/test_measurements_sparse.py
+++ b/tests/test_measurements_sparse.py
@@ -14,17 +14,14 @@
 """
 Unit tests for Sparse Measurements Lightning devices.
 """
+import pytest
+from conftest import device_name, LightningDevice as ld
+
 import numpy as np
 import pennylane as qml
 from pennylane import qchem
 
-import pytest
-
-from pennylane_lightning import CPP_BINARY_AVAILABLE, backend_info
-
-from conftest import LightningDevice, device_name
-
-if not CPP_BINARY_AVAILABLE:
+if not ld._CPP_BINARY_AVAILABLE:
     pytest.skip("No binary module found. Skipping.", allow_module_level=True)
 
 
@@ -36,7 +33,8 @@ class TestSparseExpval:
         return qml.device(device_name, wires=2, c_dtype=request.param)
 
     @pytest.mark.skipif(
-        backend_info()["USE_SPMV"], reason="Sparse matrix-vector product unavailable."
+        ld._backend_info()["USE_SPMV"],
+        reason="Sparse matrix-vector product unavailable.",
     )
     def test_create_device_with_unsupported_dtype(self, dev):
         @qml.qnode(dev, diff_method="parameter-shift")
@@ -68,7 +66,8 @@ class TestSparseExpval:
         ],
     )
     @pytest.mark.skipif(
-        not backend_info()["USE_SPMV"], reason="Sparse matrix-vector product available."
+        not ld._backend_info()["USE_SPMV"],
+        reason="Sparse matrix-vector product available.",
     )
     def test_sparse_Pauli_words(self, cases, tol, dev):
         """Test expval of some simple sparse Hamiltonian"""
@@ -135,7 +134,8 @@ class TestSparseExpvalQChem:
         ],
     )
     @pytest.mark.skipif(
-        not backend_info()["USE_SPMV"], reason="Sparse matrix-vector product unavailable."
+        not ld._backend_info()["USE_SPMV"],
+        reason="Sparse matrix-vector product unavailable.",
     )
     def test_sparse_Pauli_words(self, qubits, wires, H_sparse, hf_state, excitations, tol, dev):
         """Test expval of some simple sparse Hamiltonian"""

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -15,33 +15,37 @@
 Unit tests for the serialization helper functions.
 """
 import pytest
-from unittest import mock
+from conftest import device_name
 
 import numpy as np
-
-
 import pennylane as qml
-import pennylane_lightning
-from pennylane_lightning._serialize import (
-    _serialize_observables,
-    _serialize_ops,
-    _serialize_ob,
-)
-from pennylane_lightning import CPP_BINARY_AVAILABLE
+from pennylane_lightning._serialize import _Serialize
 
-if not CPP_BINARY_AVAILABLE:
-    pytest.skip("No binary module found. Skipping.", allow_module_level=True)
-
-from pennylane_lightning.pennylane_lightning_ops.observables import (
-    NamedObsC64,
-    NamedObsC128,
-    HermitianObsC64,
-    HermitianObsC128,
-    TensorProdObsC64,
-    TensorProdObsC128,
-    HamiltonianC64,
-    HamiltonianC128,
-)
+try:
+    from pennylane_lightning.lightning_qubit_ops.observables import (
+        NamedObsC64,
+        NamedObsC128,
+        HermitianObsC64,
+        HermitianObsC128,
+        TensorProdObsC64,
+        TensorProdObsC128,
+        HamiltonianC64,
+        HamiltonianC128,
+    )
+except ImportError:
+    try:
+        from .lightning_kokkos_ops.observables import (
+            NamedObsC64,
+            NamedObsC128,
+            HermitianObsC64,
+            HermitianObsC128,
+            TensorProdObsC64,
+            TensorProdObsC128,
+            HamiltonianC64,
+            HamiltonianC128,
+        )
+    except ImportError:
+        pytest.skip("No binary module found. Skipping.", allow_module_level=True)
 
 
 @pytest.mark.parametrize(
@@ -74,56 +78,13 @@ from pennylane_lightning.pennylane_lightning_ops.observables import (
 )
 def test_obs_returns_expected_type(obs, obs_type):
     """Tests that observables get serialized to the expected type."""
-    assert isinstance(_serialize_ob(obs, dict(enumerate(obs.wires)), False), obs_type)
+    assert isinstance(_Serialize(device_name)._ob(obs, dict(enumerate(obs.wires)), False), obs_type)
 
 
 class TestSerializeObs:
-    """Tests for the _serialize_observables function"""
+    """Tests for the _observables function"""
 
     wires_dict = {i: i for i in range(10)}
-
-    @pytest.mark.parametrize("ObsFunc", [NamedObsC128, NamedObsC64])
-    def test_basic_return(self, monkeypatch, ObsFunc):
-        """Test expected serialization for a simple return"""
-        with qml.tape.QuantumTape() as tape:
-            qml.expval(qml.PauliZ(0))
-
-        mock_obs = mock.MagicMock()
-
-        use_csingle = True if ObsFunc == NamedObsC64 else False
-        obs_str = "NamedObsC64" if ObsFunc == NamedObsC64 else "NamedObsC128"
-
-        with monkeypatch.context() as m:
-            m.setattr(pennylane_lightning._serialize, obs_str, mock_obs)
-            _serialize_observables(tape, self.wires_dict, use_csingle=use_csingle)
-
-        s = mock_obs.call_args[0]
-        s_expected = ("PauliZ", [0])
-        ObsFunc(*s_expected)
-
-        assert s == s_expected
-
-    @pytest.mark.parametrize("use_csingle", [True, False])
-    def test_tensor_return(self, monkeypatch, use_csingle):
-        """Test expected serialization for a tensor product return"""
-        with qml.tape.QuantumTape() as tape:
-            qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
-
-        mock_obs = mock.MagicMock()
-
-        ObsFunc = TensorProdObsC64 if use_csingle else TensorProdObsC128
-        named_obs = NamedObsC64 if use_csingle else NamedObsC128
-        obs_str = "TensorProdObsC64" if use_csingle else "TensorProdObsC128"
-
-        with monkeypatch.context() as m:
-            m.setattr(pennylane_lightning._serialize, obs_str, mock_obs)
-            _serialize_observables(tape, self.wires_dict, use_csingle=use_csingle)
-
-        s = mock_obs.call_args[0]
-        s_expected = ([named_obs("PauliZ", [0]), named_obs("PauliZ", [1])],)
-        ObsFunc(*s_expected)
-
-        assert s == s_expected
 
     @pytest.mark.parametrize("use_csingle", [True, False])
     def test_tensor_non_tensor_return(self, use_csingle):
@@ -136,7 +97,7 @@ class TestSerializeObs:
         tensor_prod_obs = TensorProdObsC64 if use_csingle else TensorProdObsC128
         named_obs = NamedObsC64 if use_csingle else NamedObsC128
 
-        s = _serialize_observables(tape, self.wires_dict, use_csingle=use_csingle)
+        s = _Serialize(device_name)._observables(tape, self.wires_dict, use_csingle=use_csingle)
 
         s_expected = [
             tensor_prod_obs([named_obs("PauliZ", [0]), named_obs("PauliX", [1])]),
@@ -154,7 +115,7 @@ class TestSerializeObs:
         hermitian_obs = HermitianObsC64 if use_csingle else HermitianObsC128
         c_dtype = np.complex64 if use_csingle else np.complex128
 
-        s = _serialize_observables(tape, self.wires_dict, use_csingle=use_csingle)
+        s = _Serialize(device_name)._observables(tape, self.wires_dict, use_csingle=use_csingle)
         s_expected = hermitian_obs(
             np.array(
                 [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0],
@@ -173,7 +134,7 @@ class TestSerializeObs:
         c_dtype = np.complex64 if use_csingle else np.complex128
         tensor_prod_obs = TensorProdObsC64 if use_csingle else TensorProdObsC128
         hermitian_obs = HermitianObsC64 if use_csingle else HermitianObsC128
-        s = _serialize_observables(tape, self.wires_dict, use_csingle=use_csingle)
+        s = _Serialize(device_name)._observables(tape, self.wires_dict, use_csingle=use_csingle)
 
         s_expected = tensor_prod_obs(
             [
@@ -195,7 +156,7 @@ class TestSerializeObs:
         hermitian_obs = HermitianObsC64 if use_csingle else HermitianObsC128
         named_obs = NamedObsC64 if use_csingle else NamedObsC128
 
-        s = _serialize_observables(tape, self.wires_dict, use_csingle=use_csingle)
+        s = _Serialize(device_name)._observables(tape, self.wires_dict, use_csingle=use_csingle)
 
         s_expected = tensor_prod_obs(
             [hermitian_obs(np.eye(4, dtype=c_dtype).ravel(), [0, 1]), named_obs("PauliY", [2])]
@@ -226,7 +187,7 @@ class TestSerializeObs:
         r_dtype = np.float32 if use_csingle else np.float64
         c_dtype = np.complex64 if use_csingle else np.complex128
 
-        s = _serialize_observables(tape, self.wires_dict, use_csingle=use_csingle)
+        s = _Serialize(device_name)._observables(tape, self.wires_dict, use_csingle=use_csingle)
 
         s_expected = hamiltonian_obs(
             np.array([0.3, 0.5, 0.4], dtype=r_dtype),
@@ -266,7 +227,7 @@ class TestSerializeObs:
         r_dtype = np.float32 if use_csingle else np.float64
         c_dtype = np.complex64 if use_csingle else np.complex128
 
-        s = _serialize_observables(tape, self.wires_dict, use_csingle=use_csingle)
+        s = _Serialize(device_name)._observables(tape, self.wires_dict, use_csingle=use_csingle)
 
         # Expression (ham @ obs) is converted internally by Pennylane
         # where obs is appended to each term of the ham
@@ -319,7 +280,7 @@ class TestSerializeObs:
         r_dtype = np.float32 if use_csingle else np.float64
         c_dtype = np.complex64 if use_csingle else np.complex128
 
-        s = _serialize_observables(tape, self.wires_dict, use_csingle=use_csingle)
+        s = _Serialize(device_name)._observables(tape, self.wires_dict, use_csingle=use_csingle)
 
         s_expected1 = hamiltonian_obs(
             np.array([0.3, 0.5, 0.4], dtype=r_dtype),
@@ -369,7 +330,7 @@ class TestSerializeObs:
     def test_op_arithmetic_uses_hamiltonian(self, use_csingle, obs, coeffs, terms):
         """Tests that an arithmetic obs with a PauliRep serializes as a Hamiltonian."""
         tape = qml.tape.QuantumTape(measurements=[qml.expval(obs)])
-        res = _serialize_observables(tape, self.wires_dict, use_csingle=use_csingle)
+        res = _Serialize(device_name)._observables(tape, self.wires_dict, use_csingle=use_csingle)
         assert len(res) == 1
         assert isinstance(res[0], HamiltonianC64 if use_csingle else HamiltonianC128)
 
@@ -393,7 +354,7 @@ class TestSerializeObs:
     def test_multi_wire_identity(self, use_csingle):
         """Tests that multi-wire Identity does not fail serialization."""
         tape = qml.tape.QuantumTape(measurements=[qml.expval(qml.Identity(wires=[1, 2]))])
-        res = _serialize_observables(tape, self.wires_dict, use_csingle=use_csingle)
+        res = _Serialize(device_name)._observables(tape, self.wires_dict, use_csingle=use_csingle)
         assert len(res) == 1
 
         named_obs = NamedObsC64 if use_csingle else NamedObsC128
@@ -401,7 +362,7 @@ class TestSerializeObs:
 
 
 class TestSerializeOps:
-    """Tests for the _serialize_ops function"""
+    """Tests for the _ops function"""
 
     wires_dict = {i: i for i in range(10)}
 
@@ -412,7 +373,7 @@ class TestSerializeOps:
             qml.RY(0.6, wires=1)
             qml.CNOT(wires=[0, 1])
 
-        s = _serialize_ops(tape, self.wires_dict)
+        s = _Serialize(device_name)._ops(tape, self.wires_dict)
         s_expected = (
             (
                 ["RX", "RY", "CNOT"],
@@ -435,7 +396,7 @@ class TestSerializeOps:
             qml.RY(0.6, wires=1)
             qml.CNOT(wires=[0, 1])
 
-        s = _serialize_ops(tape, self.wires_dict)
+        s = _Serialize(device_name)._ops(tape, self.wires_dict)
         s_expected = (
             (
                 ["RX", "RY", "CNOT"],
@@ -455,7 +416,7 @@ class TestSerializeOps:
             qml.CNOT(wires=[0, 1])
             qml.RZ(0.2, wires=2)
 
-        s = _serialize_ops(tape, self.wires_dict)
+        s = _Serialize(device_name)._ops(tape, self.wires_dict)
         s_expected = (
             (
                 ["CNOT", "RZ"],
@@ -479,7 +440,7 @@ class TestSerializeOps:
             qml.SingleExcitationPlus(0.4, wires=["a", 3.2])
             qml.adjoint(qml.SingleExcitationMinus(0.5, wires=["a", 3.2]), lazy=False)
 
-        s = _serialize_ops(tape, wires_dict)
+        s = _Serialize(device_name)._ops(tape, wires_dict)
         s_expected = (
             (
                 [
@@ -512,7 +473,7 @@ class TestSerializeOps:
             qml.DoubleExcitationMinus(0.555, wires=[0, 1, 2, 3])
             qml.DoubleExcitationPlus(0.555, wires=[0, 1, 2, 3])
 
-        s = _serialize_ops(tape, self.wires_dict)
+        s = _Serialize(device_name)._ops(tape, self.wires_dict)
 
         dtype = np.complex64 if C else np.complex128
         s_expected = (

--- a/tests/test_serialize_chunk_obs.py
+++ b/tests/test_serialize_chunk_obs.py
@@ -14,20 +14,17 @@
 """
 Unit tests for the serialization helper functions.
 """
+import pytest
+from conftest import device_name, LightningDevice as ld
+
 import pennylane as qml
 import numpy as np
 import pennylane_lightning
 
-from pennylane_lightning._serialize import _serialize_observables
-import pytest
+from pennylane_lightning._serialize import _Serialize
 
-from pennylane_lightning import CPP_BINARY_AVAILABLE, backend_info
-
-if not CPP_BINARY_AVAILABLE:
+if not ld._CPP_BINARY_AVAILABLE:
     pytest.skip("No binary module found. Skipping.", allow_module_level=True)
-
-if backend_info()["NAME"] != "lightning.qubit":
-    pytest.skip("Exclusive tests for lightning.qubit. Skipping.", allow_module_level=True)
 
 
 class TestSerializeObs:
@@ -44,6 +41,6 @@ class TestSerializeObs:
             qml.expval(qml.PauliY(wires=1))
             qml.expval(qml.PauliX(0) @ qml.Hermitian([[0, 1], [1, 0]], wires=3) @ qml.Hadamard(2))
             qml.expval(qml.Hermitian(qml.PauliZ.compute_matrix(), wires=0) @ qml.Identity(1))
-        s = _serialize_observables(tape, self.wires_dict, use_csingle=use_csingle)
-        obtained_chunks = pennylane_lightning.lightning_qubit._chunk_iterable(s, obs_chunk)
+        s = _Serialize(device_name)._observables(tape, self.wires_dict, use_csingle=use_csingle)
+        obtained_chunks = pennylane_lightning.lightning_base._chunk_iterable(s, obs_chunk)
         assert len(list(obtained_chunks)) == int(np.ceil(len(s) / obs_chunk))

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -15,11 +15,10 @@
 Unit tests for the var method of the :mod:`pennylane_lightning.LightningQubit` device.
 """
 import pytest
+from conftest import THETA, PHI, VARPHI
 
 import numpy as np
 import pennylane as qml
-
-from conftest import THETA, PHI, VARPHI
 
 np.random.seed(42)
 

--- a/tests/test_vjp.py
+++ b/tests/test_vjp.py
@@ -15,15 +15,13 @@
 Tests for the ``vjp`` method of LightningKokkos.
 """
 import pytest
-import math
+from conftest import device_name, LightningDevice as ld
 
+import math
 import pennylane as qml
 from pennylane import numpy as np
 
-from pennylane_lightning import CPP_BINARY_AVAILABLE, backend_info
-from conftest import device_name
-
-if not CPP_BINARY_AVAILABLE:
+if not ld._CPP_BINARY_AVAILABLE:
     pytest.skip("No binary module found. Skipping.", allow_module_level=True)
 
 


### PR DESCRIPTION
This PR changes the binaries naming to be device-specific.
This change will allow to have binaries for any number of backends (LightningQubit and LightningKokkos for the moment) at the same time.